### PR TITLE
export fix

### DIFF
--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -9,5 +9,3 @@ const middlewares = [logger];
 export const store = createStore(rootReducer, applyMiddleware(...middlewares));
 
 export const persistor = persistStore(store);
-
-export default { store, persistStore };


### PR DESCRIPTION
Persistor should be exported, not persistStore. But the whole line 'export default {store, persistor} ' is uneccessary due to the above already exported store and persistor (even though its mentioned in video that they are not needed). But if you remove them, the 'export default' doesnt work. According to react it is better to use export default only if there is single export. (in this case we have 2 -> store and persistor). It should be exported like this, without export default